### PR TITLE
Bringing over some fixed unit tests from the cta-demo repo

### DIFF
--- a/examples/transmitter/swagger_server/test/test_jwt_encode.py
+++ b/examples/transmitter/swagger_server/test/test_jwt_encode.py
@@ -7,7 +7,10 @@ from pathlib import Path
 import uuid
 
 from jwcrypto.jwk import JWK, JWKSet
+
+from py._path.local import LocalPath
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from swagger_server import jwt_encode
 
@@ -126,7 +129,7 @@ class TestGetJWKSPath:
 
 
 class TestSaveJWKS:
-    def test_makes_file(self, monkeypatch, tmpdir) -> None:
+    def test_makes_file(self, monkeypatch: MonkeyPatch, tmpdir: LocalPath) -> None:
         """Ensures we are able to save a JWKS file to disk"""
         temp_base = tmpdir.mkdir("mock")
         monkeypatch.setenv("JWKS_PATH", f"{temp_base}/foo/bar/jwks.json")
@@ -136,7 +139,7 @@ class TestSaveJWKS:
         jwt_encode.save_jwks(mock_jwks)
         assert jwt_encode.get_jwks_path().exists()
 
-    def test_makes_needed_directories(self, monkeypatch, tmpdir) -> None:
+    def test_makes_needed_directories(self, monkeypatch: MonkeyPatch, tmpdir: LocalPath) -> None:
         """Ensures the saving process creates all needed directories"""
         temp_base = tmpdir.mkdir("mock")
         monkeypatch.setenv("JWKS_PATH", f"{temp_base}/foo/bar/jwks.json")
@@ -148,7 +151,7 @@ class TestSaveJWKS:
 
 
 class TestLoadJWKS:
-    def test_loads_jwks(self, monkeypatch, tmpdir) -> None:
+    def test_loads_jwks(self, monkeypatch: MonkeyPatch, tmpdir: LocalPath) -> None:
         """Ensures we are able to load a JWKS file from disk"""
         temp_base = tmpdir.mkdir("mock")
         monkeypatch.setenv("JWKS_PATH", f"{temp_base}/foo/bar/jwks.json")


### PR DESCRIPTION
Ensures that tests are using a properly cleaned up tmpdir to save the JWKS file, thus avoiding some flaky tests. Also removes a few annotations on the tests that seem like overkill.