### PR TITLE
A way to test out security event other than the verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The work provided here is intended as educational material and as a proof-of-con
 We welcome further contributions from the open source community.
 Please check the [Issues](https://github.com/duo-labs/sharedsignals/issues)
 section for ideas about where to start.
+Use [pycodestyle](https://pycodestyle.pycqa.org/en/latest/) to make sure that your code follows the PEP8 standard.
 
 ### Adding License Headers
 The content in this repository was initially created by engineers at

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to a new file if desired.
 The work provided here is intended as educational material and as a proof-of-concept.
 We welcome further contributions from the open source community.
 Please check the [Issues](https://github.com/duo-labs/sharedsignals/issues)
-section for ideas about where to start.
+section for ideas about where to start. \
 Use [pycodestyle](https://pycodestyle.pycqa.org/en/latest/) to make sure that your code follows the PEP8 standard.
 
 ### Adding License Headers

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ to generate an event to demonstrate the PUSH capability.
 After you have the Swagger UI up, as per instructions [here](transmitter/README.md).
 You can use the out-of-band (**NOT** openid standard) transmitter endpoint `trigger-event`,
 to trigger any type of openid-sse event 
-([CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) or [RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)) 
+([CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) or [RISC](https://openid.net/specs/openid-risc-profile-specification-1_0-01.html)) 
 And the transmitter, as per the stream configuration, will either push it to the receiver, or it will be poll/pull'ed by the receiver
 .
 > Note: the subject should be same as the ones configured in the receiver [here](receiver/receiver/config.cfg), otherwise there won't be any stream that's interested in an arbitrary subject and the SET won't be sent.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,15 @@ called (via the browser or other method), will cause the receiver to request a
 Verification Event from the transmitter. This allows you to force the transmitter
 to generate an event to demonstrate the PUSH capability.
 
+## Trigger and test SSE events other than verification
+After you have the Swagger UI up, as per instructions [here](transmitter/README.md).
+You can use the out-of-band (**NOT** openid standard) transmitter endpoint `trigger-event`,
+to trigger any type of openid-sse event 
+([CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) or [RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)) 
+And the transmitter, as per the stream configuration, will either push it to the receiver, or it will be poll/pull'ed by the receiver
+.
+> Note: the subject should be same as the ones configured in the receiver [here](receiver/receiver/config.cfg), otherwise there won't be any stream that's interested in an arbitrary subject and the SET won't be sent.
+
 ## shared_signals_guide
 This collection of scripts and JSON walks through the examples shown on the
 [https://sharedsignals.guide](https://sharedsignals.guide) website. It assumes

--- a/examples/transmitter/setup.py
+++ b/examples/transmitter/setup.py
@@ -25,7 +25,8 @@ setup(
     description="Stream Management API for OpenID Shared Security Events",
     author_email="",
     url="",
-    keywords=["Swagger", "Stream Management API for OpenID Shared Security Events"],
+    keywords=["Swagger",
+              "Stream Management API for OpenID Shared Security Events"],
     install_requires=REQUIRES,
     packages=find_packages(),
     package_data={'': ['swagger/swagger.yaml']},
@@ -33,6 +34,10 @@ setup(
     entry_points={
         'console_scripts': ['swagger_server=swagger_server.__main__:main']},
     long_description="""\
-    [OpenID Spec](https://openid.net/specs/openid-sse-framework-1_0.html#management)  HTTP API to be implemented by Event Transmitters. This API can be used by Event Receivers to query and update the Event Stream configuration and status, to add and remove subjects, and to trigger verification. 
+    [OpenID Spec](https://openid.net/specs/openid-sse-framework-1_0.
+    html#management)  HTTP API to be implemented by Event Transmitters. This
+    API can be used by Event Receivers to query and update the Event Stream
+    configuration and status, to add and remove subjects, and to trigger
+    verification.
     """
 )

--- a/examples/transmitter/swagger_server/__init__.py
+++ b/examples/transmitter/swagger_server/__init__.py
@@ -2,4 +2,3 @@
 # All rights reserved.
 # Use of this source code is governed by a BSD 3-Clause License
 # that can be found in the LICENSE file.
-

--- a/examples/transmitter/swagger_server/business_logic/__init__.py
+++ b/examples/transmitter/swagger_server/business_logic/__init__.py
@@ -14,10 +14,10 @@ from swagger_server.business_logic.const import TRANSMITTER_ISSUER
 from swagger_server.business_logic.stream import Stream
 from swagger_server.business_logic.generate_event import GenerateEvent
 from swagger_server.errors import (
-EmailSubjectNotFound, LongPollingNotSupported, TransmitterError
+    EmailSubjectNotFound, LongPollingNotSupported, TransmitterError
 )
 from swagger_server.models import (
-   Email, Status, StreamConfiguration, StreamStatus, 
+   Email, Status, StreamConfiguration, StreamStatus,
    Subject, TransmitterConfiguration
 )
 from swagger_server.utils import get_simple_subject
@@ -114,8 +114,9 @@ def verification_request(state: Optional[str], client_id: str) -> None:
     stream.process_SET(security_event)
 
 
-def _well_known_sse_configuration_get(url_root: str, 
-                                      issuer: Optional[str] = None) -> TransmitterConfiguration:
+def _well_known_sse_configuration_get(url_root: str,
+                                      issuer: Optional[str] =
+                                      None) -> TransmitterConfiguration:
     return TransmitterConfiguration(
         issuer=TRANSMITTER_ISSUER + (issuer if issuer else ''),
         jwks_uri=url_root + 'jwks.json',
@@ -158,15 +159,17 @@ def poll_request(max_events: Optional[int],
 def register(audience: Union[str, List[str]]) -> Dict[str, str]:
     client_id = uuid.uuid4().hex
     Stream(client_id, audience)
-    return { 'token': client_id }
+    return {'token': client_id}
 
 
-def trigger_event(event_type:str,subject: Subject)->None:
+def trigger_event(event_type: str, subject: Subject) -> None:
     # TODO: 2. allocate a GenerateEvent only once
 
     ge = GenerateEvent()
-    security_event = ge.generate_security_event(event_type,subject)
+    security_event = ge.generate_security_event(event_type, subject)
     if security_event is None:
-        raise TransmitterError(code=500,message=f"invalid event_type:{event_type} (only RISC and CAEP supported)")
+        raise TransmitterError(code=500,
+                               message=f"invalid event_type:{event_type}"
+                               + "(only RISC and CAEP supported)")
     # and broadcast it
     Stream.broadcast_SET(security_event)

--- a/examples/transmitter/swagger_server/business_logic/__init__.py
+++ b/examples/transmitter/swagger_server/business_logic/__init__.py
@@ -4,14 +4,11 @@
 # that can be found in the LICENSE file.
 
 import logging
-import time
 import uuid
-from typing import List, Optional, Tuple, Union, Dict, Any
-
-import requests
+from typing import List, Optional, Tuple, Union, Dict
 
 from swagger_server.events import (
-    Events, SecurityEvent, VerificationEvent, SessionRevoked
+    Events, SecurityEvent, VerificationEvent
 )
 from swagger_server.business_logic.const import TRANSMITTER_ISSUER
 from swagger_server.business_logic.stream import Stream
@@ -19,14 +16,10 @@ from swagger_server.business_logic.generate_event import GenerateEvent
 from swagger_server.errors import (
 EmailSubjectNotFound, LongPollingNotSupported, TransmitterError
 )
-from swagger_server.models import StreamConfiguration
-from swagger_server.models import StreamStatus
-from swagger_server.models import Subject
-from swagger_server.models import Status
-from swagger_server.models import Email
-
-from swagger_server.models import TransmitterConfiguration  # noqa: E501
-
+from swagger_server.models import (
+   Email, Status, StreamConfiguration, StreamStatus, 
+   Subject, TransmitterConfiguration
+)
 from swagger_server.utils import get_simple_subject
 
 log = logging.getLogger(__name__)
@@ -170,8 +163,7 @@ def register(audience: Union[str, List[str]]) -> Dict[str, str]:
 
 def trigger_event(event_type:str,subject: Subject)->None:
     # TODO: 2. allocate a GenerateEvent only once
-    # TODO: 3. All fields of the SET should be populated
-    # TODO: 4. Some fields of the SET should be pseudo-random
+
     ge = GenerateEvent()
     security_event = ge.generate_security_event(event_type,subject)
     if security_event is None:

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -1,0 +1,94 @@
+import logging
+import time
+import uuid
+
+from swagger_server.events import (
+    Events, SecurityEvent,
+    SessionRevoked,TokenClaimsChange, CredentialChange,
+    AssuranceLevelChange, DeviceComplianceChange
+)
+
+from swagger_server.models import Subject
+
+TIMESTAMP=873645873
+ADMIN_MSG = dict(en="Device compliance change")
+USER_MSG = dict(en="Device out of compliance: firewall off")
+
+# TODO: 1. Support RISC
+class GenerateEvent:
+    def __init__(self):
+        self.event_generation_map = {
+            "session-revoked": self.session_revoked_event,
+            "token-claims-change": self.token_claims_change_event,
+            "credential-change": self.credential_change_event,
+            "assurance-level-change": self.assurance_level_change_event,
+            "device-compliance-change": self.device_compliance_change_event
+        }
+        self.subject:Subject
+
+    
+    def session_revoked_event(self)->SecurityEvent:
+        session_revoked = SessionRevoked( subject=self.subject,
+                        event_timestamp=TIMESTAMP,
+                        initiating_entity="Duo policy",
+                        reason_admin=ADMIN_MSG,
+                        reason_user=USER_MSG)
+        return SecurityEvent(
+        events=Events(session_revoked=session_revoked)
+    )
+    
+    def token_claims_change_event(self)->SecurityEvent:
+        token_claims_change = TokenClaimsChange( subject=self.subject,
+                        event_timestamp=TIMESTAMP,
+                        initiating_entity="Duo policy",
+                        reason_admin=ADMIN_MSG,
+                        reason_user=USER_MSG,
+                        claims={"trusted_network": "false"})
+        return SecurityEvent(
+        events=Events(token_claims_change=token_claims_change)
+    )
+        
+    def credential_change_event(self)->SecurityEvent:
+        credential_change = CredentialChange( subject=self.subject,
+                        event_timestamp=TIMESTAMP,
+                        initiating_entity="Duo policy",
+                        reason_admin=ADMIN_MSG,
+                        reason_user=USER_MSG,
+                        credential_type="",
+                        change_type="")
+        return SecurityEvent(
+        events=Events(credential_change=credential_change)
+    )
+        
+    def assurance_level_change_event(self)->SecurityEvent:
+        assurance_level_change = AssuranceLevelChange( subject=self.subject,
+                        event_timestamp=TIMESTAMP,
+                        initiating_entity="Duo policy",
+                        reason_admin=ADMIN_MSG,
+                        reason_user=USER_MSG,
+                        current_level="",
+                        previous_level="",
+                        change_direction="")
+        return SecurityEvent(
+        events=Events(assurance_level_change=assurance_level_change)
+    )
+        
+    def device_compliance_change_event(self)->SecurityEvent:
+        device_compliance_change = DeviceComplianceChange( subject=self.subject,
+                        event_timestamp=TIMESTAMP,
+                        initiating_entity="Duo policy",
+                        reason_admin=ADMIN_MSG,
+                        reason_user=USER_MSG,
+                        current_status="",
+                        previous_status="")
+        return SecurityEvent(
+        events=Events(device_compliance_change=device_compliance_change)
+    )
+        
+    def generate_security_event(self,event_type:str,subject:Subject)->SecurityEvent:
+        if event_type not in self.event_generation_map:
+            return None
+
+        event_generation_function = self.event_generation_map[event_type]
+        self.subject = subject
+        return event_generation_function()

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -3,23 +3,39 @@
 # Use of this source code is governed by a BSD 3-Clause License
 # that can be found in the LICENSE file.
 
+
 from swagger_server.events import (
     SecurityEvent,
     SessionRevoked, TokenClaimsChange, CredentialChange,
-    AssuranceLevelChange, DeviceComplianceChange
+    AssuranceLevelChange, DeviceComplianceChange,
+    AccountDisabled, AccountEnabled, AccountPurged, IdentifierChanged,
+    IdentifierRecycled, OptIn, OptOutCancelled, OptOutEffective,
+    OptOutInitiated, RISCSessionsRevoked, RecoveryActivated,
+    RecoveryInformationChanged
 )
 from swagger_server.models import (
    Subject, EventType
 )
 
 
-# TODO: 1. Support RISC
 event_type_map = {
     EventType.session_revoked: SessionRevoked,
     EventType.token_claims_change: TokenClaimsChange,
     EventType.credential_change: CredentialChange,
     EventType.assurance_level_change: AssuranceLevelChange,
-    EventType.device_compliance_change: DeviceComplianceChange
+    EventType.device_compliance_change: DeviceComplianceChange,
+    EventType.account_purged: AccountPurged,
+    EventType.account_disabled: AccountDisabled,
+    EventType.account_enabled: AccountEnabled,
+    EventType.identifier_changed: IdentifierChanged,
+    EventType.identifier_recycled: IdentifierRecycled,
+    EventType.opt_in: OptIn,
+    EventType.opt_out_initiated: OptOutInitiated,
+    EventType.opt_out_cancelled: OptOutCancelled,
+    EventType.opt_out_effective: OptOutEffective,
+    EventType.recovery_activated: RecoveryActivated,
+    EventType.recovery_information_changed: RecoveryInformationChanged,
+    EventType.RISC_sessions_revoked: RISCSessionsRevoked,
 }
 
 

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -8,11 +8,12 @@ from typing import Dict
 
 from swagger_server.events import (
     Events, SecurityEvent,
-    SessionRevoked,TokenClaimsChange, CredentialChange,
+    SessionRevoked, TokenClaimsChange, CredentialChange,
     AssuranceLevelChange, DeviceComplianceChange
 )
 
 from swagger_server.models import Subject
+
 
 # TODO: 1. Support RISC
 class GenerateEvent:
@@ -24,69 +25,42 @@ class GenerateEvent:
             "assurance-level-change": self.assurance_level_change_event,
             "device-compliance-change": self.device_compliance_change_event
         }
-        self.subject:Subject
-        self.event_type:str
+        self.subject: Subject
+        self.event_type: str
 
-    
-    def session_revoked_event(self)->SecurityEvent:
-        session_revoked = SessionRevoked( subject=self.subject,
-                        event_timestamp=self.gen_timestamp(),
-                        initiating_entity="Duo policy",
-                        reason_admin=self.gen_admin_msg(),
-                        reason_user=self.gen_user_msg())
+    def session_revoked_event(self) -> SecurityEvent:
+        session_revoked = SessionRevoked(subject=self.subject)
         return SecurityEvent(
-        events=Events(session_revoked=session_revoked)
-    )
-    
-    def token_claims_change_event(self)->SecurityEvent:
-        token_claims_change = TokenClaimsChange( subject=self.subject,
-                        event_timestamp=self.gen_timestamp(),
-                        initiating_entity="Duo policy",
-                        reason_admin=self.gen_admin_msg(),
-                        reason_user=self.gen_user_msg(),
-                        claims={"trusted_network": "false"})
+                events=Events(session_revoked=session_revoked)
+                )
+
+    def token_claims_change_event(self) -> SecurityEvent:
+        token_claims_change = TokenClaimsChange(subject=self.subject)
         return SecurityEvent(
-        events=Events(token_claims_change=token_claims_change)
-    )
-        
-    def credential_change_event(self)->SecurityEvent:
-        credential_change = CredentialChange( subject=self.subject,
-                        event_timestamp=self.gen_timestamp(),
-                        initiating_entity="Duo policy",
-                        reason_admin=self.gen_admin_msg(),
-                        reason_user=self.gen_user_msg(),
-                        credential_type="fido2-roaming",
-                        change_type="create")
+                events=Events(token_claims_change=token_claims_change)
+            )
+
+    def credential_change_event(self) -> SecurityEvent:
+        credential_change = CredentialChange(subject=self.subject)
         return SecurityEvent(
-        events=Events(credential_change=credential_change)
-    )
-        
-    def assurance_level_change_event(self)->SecurityEvent:
-        assurance_level_change = AssuranceLevelChange( subject=self.subject,
-                        event_timestamp=self.gen_timestamp(),
-                        initiating_entity="Duo policy",
-                        reason_admin=self.gen_admin_msg(),
-                        reason_user=self.gen_user_msg(),
-                        current_level="nist-aal2",
-                        previous_level="nist-aal1",
-                        change_direction="increase")
+                events=Events(credential_change=credential_change)
+            )
+
+    def assurance_level_change_event(self) -> SecurityEvent:
+        assurance_level_change = AssuranceLevelChange(subject=self.subject)
         return SecurityEvent(
-        events=Events(assurance_level_change=assurance_level_change)
-    )
-        
-    def device_compliance_change_event(self)->SecurityEvent:
-        device_compliance_change = DeviceComplianceChange( subject=self.subject,
-                        event_timestamp=self.gen_timestamp(),
-                        initiating_entity="Duo policy",
-                        reason_admin=self.gen_admin_msg(),
-                        reason_user=self.gen_user_msg(),
-                        current_status="compliant",
-                        previous_status="not-compliant")
+                events=Events(assurance_level_change=assurance_level_change)
+            )
+
+    def device_compliance_change_event(self) -> SecurityEvent:
+        device_compliance_change = DeviceComplianceChange(subject=self.subject)
         return SecurityEvent(
-        events=Events(device_compliance_change=device_compliance_change)
-    )
-        
-    def generate_security_event(self,event_type:str,subject:Subject)->SecurityEvent:
+                events=Events(device_compliance_change=
+                              device_compliance_change)
+            )
+
+    def generate_security_event(self, event_type: str,
+                                subject: Subject) -> SecurityEvent:
         if event_type not in self.event_generation_map:
             return None
 
@@ -94,13 +68,3 @@ class GenerateEvent:
         event_generation_function = self.event_generation_map[event_type]
         self.subject = subject
         return event_generation_function()
-    
-    @staticmethod
-    def gen_timestamp()->int:
-        return time.time() #returns the unix timestamp
-    
-    def gen_admin_msg(self)->Dict[str,str]:
-        return dict(en=f"{self.event_type} admin message")
-    
-    def gen_user_msg(self)->Dict[str,str]:
-        return dict(en=f"{self.event_type} user message")

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -3,68 +3,33 @@
 # Use of this source code is governed by a BSD 3-Clause License
 # that can be found in the LICENSE file.
 
-import time
-from typing import Dict
-
 from swagger_server.events import (
-    Events, SecurityEvent,
+    SecurityEvent,
     SessionRevoked, TokenClaimsChange, CredentialChange,
     AssuranceLevelChange, DeviceComplianceChange
 )
-
-from swagger_server.models import Subject
+from swagger_server.models import (
+   Subject, EventType
+)
 
 
 # TODO: 1. Support RISC
-class GenerateEvent:
-    def __init__(self):
-        self.event_generation_map = {
-            "session-revoked": self.session_revoked_event,
-            "token-claims-change": self.token_claims_change_event,
-            "credential-change": self.credential_change_event,
-            "assurance-level-change": self.assurance_level_change_event,
-            "device-compliance-change": self.device_compliance_change_event
+event_type_map = {
+    EventType.session_revoked: SessionRevoked,
+    EventType.token_claims_change: TokenClaimsChange,
+    EventType.credential_change: CredentialChange,
+    EventType.assurance_level_change: AssuranceLevelChange,
+    EventType.device_compliance_change: DeviceComplianceChange
+}
+
+
+def generate_security_event(event_type: EventType,
+                            subject: Subject) -> SecurityEvent:
+    event_class = event_type_map[event_type]
+    event_attribute_name = event_type.value.replace("-", "_")
+    security_event = {
+        "events": {
+            event_attribute_name: event_class(subject=subject),
         }
-        self.subject: Subject
-        self.event_type: str
-
-    def session_revoked_event(self) -> SecurityEvent:
-        session_revoked = SessionRevoked(subject=self.subject)
-        return SecurityEvent(
-                events=Events(session_revoked=session_revoked)
-                )
-
-    def token_claims_change_event(self) -> SecurityEvent:
-        token_claims_change = TokenClaimsChange(subject=self.subject)
-        return SecurityEvent(
-                events=Events(token_claims_change=token_claims_change)
-            )
-
-    def credential_change_event(self) -> SecurityEvent:
-        credential_change = CredentialChange(subject=self.subject)
-        return SecurityEvent(
-                events=Events(credential_change=credential_change)
-            )
-
-    def assurance_level_change_event(self) -> SecurityEvent:
-        assurance_level_change = AssuranceLevelChange(subject=self.subject)
-        return SecurityEvent(
-                events=Events(assurance_level_change=assurance_level_change)
-            )
-
-    def device_compliance_change_event(self) -> SecurityEvent:
-        device_compliance_change = DeviceComplianceChange(subject=self.subject)
-        return SecurityEvent(
-                events=Events(device_compliance_change=
-                              device_compliance_change)
-            )
-
-    def generate_security_event(self, event_type: str,
-                                subject: Subject) -> SecurityEvent:
-        if event_type not in self.event_generation_map:
-            return None
-
-        self.event_type = event_type
-        event_generation_function = self.event_generation_map[event_type]
-        self.subject = subject
-        return event_generation_function()
+    }
+    return SecurityEvent.parse_obj(security_event)

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -1,6 +1,10 @@
-import logging
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+# Use of this source code is governed by a BSD 3-Clause License
+# that can be found in the LICENSE file.
+
 import time
-import uuid
+from typing import Dict
 
 from swagger_server.events import (
     Events, SecurityEvent,
@@ -9,10 +13,6 @@ from swagger_server.events import (
 )
 
 from swagger_server.models import Subject
-
-TIMESTAMP=873645873
-ADMIN_MSG = dict(en="Device compliance change")
-USER_MSG = dict(en="Device out of compliance: firewall off")
 
 # TODO: 1. Support RISC
 class GenerateEvent:
@@ -25,24 +25,25 @@ class GenerateEvent:
             "device-compliance-change": self.device_compliance_change_event
         }
         self.subject:Subject
+        self.event_type:str
 
     
     def session_revoked_event(self)->SecurityEvent:
         session_revoked = SessionRevoked( subject=self.subject,
-                        event_timestamp=TIMESTAMP,
+                        event_timestamp=self.gen_timestamp(),
                         initiating_entity="Duo policy",
-                        reason_admin=ADMIN_MSG,
-                        reason_user=USER_MSG)
+                        reason_admin=self.gen_admin_msg(),
+                        reason_user=self.gen_user_msg())
         return SecurityEvent(
         events=Events(session_revoked=session_revoked)
     )
     
     def token_claims_change_event(self)->SecurityEvent:
         token_claims_change = TokenClaimsChange( subject=self.subject,
-                        event_timestamp=TIMESTAMP,
+                        event_timestamp=self.gen_timestamp(),
                         initiating_entity="Duo policy",
-                        reason_admin=ADMIN_MSG,
-                        reason_user=USER_MSG,
+                        reason_admin=self.gen_admin_msg(),
+                        reason_user=self.gen_user_msg(),
                         claims={"trusted_network": "false"})
         return SecurityEvent(
         events=Events(token_claims_change=token_claims_change)
@@ -50,37 +51,37 @@ class GenerateEvent:
         
     def credential_change_event(self)->SecurityEvent:
         credential_change = CredentialChange( subject=self.subject,
-                        event_timestamp=TIMESTAMP,
+                        event_timestamp=self.gen_timestamp(),
                         initiating_entity="Duo policy",
-                        reason_admin=ADMIN_MSG,
-                        reason_user=USER_MSG,
-                        credential_type="",
-                        change_type="")
+                        reason_admin=self.gen_admin_msg(),
+                        reason_user=self.gen_user_msg(),
+                        credential_type="fido2-roaming",
+                        change_type="create")
         return SecurityEvent(
         events=Events(credential_change=credential_change)
     )
         
     def assurance_level_change_event(self)->SecurityEvent:
         assurance_level_change = AssuranceLevelChange( subject=self.subject,
-                        event_timestamp=TIMESTAMP,
+                        event_timestamp=self.gen_timestamp(),
                         initiating_entity="Duo policy",
-                        reason_admin=ADMIN_MSG,
-                        reason_user=USER_MSG,
-                        current_level="",
-                        previous_level="",
-                        change_direction="")
+                        reason_admin=self.gen_admin_msg(),
+                        reason_user=self.gen_user_msg(),
+                        current_level="nist-aal2",
+                        previous_level="nist-aal1",
+                        change_direction="increase")
         return SecurityEvent(
         events=Events(assurance_level_change=assurance_level_change)
     )
         
     def device_compliance_change_event(self)->SecurityEvent:
         device_compliance_change = DeviceComplianceChange( subject=self.subject,
-                        event_timestamp=TIMESTAMP,
+                        event_timestamp=self.gen_timestamp(),
                         initiating_entity="Duo policy",
-                        reason_admin=ADMIN_MSG,
-                        reason_user=USER_MSG,
-                        current_status="",
-                        previous_status="")
+                        reason_admin=self.gen_admin_msg(),
+                        reason_user=self.gen_user_msg(),
+                        current_status="compliant",
+                        previous_status="not-compliant")
         return SecurityEvent(
         events=Events(device_compliance_change=device_compliance_change)
     )
@@ -89,6 +90,17 @@ class GenerateEvent:
         if event_type not in self.event_generation_map:
             return None
 
+        self.event_type = event_type
         event_generation_function = self.event_generation_map[event_type]
         self.subject = subject
         return event_generation_function()
+    
+    @staticmethod
+    def gen_timestamp()->int:
+        return time.time() #returns the unix timestamp
+    
+    def gen_admin_msg(self)->Dict[str,str]:
+        return dict(en=f"{self.event_type} admin message")
+    
+    def gen_user_msg(self)->Dict[str,str]:
+        return dict(en=f"{self.event_type} user message")

--- a/examples/transmitter/swagger_server/business_logic/generate_event.py
+++ b/examples/transmitter/swagger_server/business_logic/generate_event.py
@@ -9,8 +9,8 @@ from swagger_server.events import (
     SessionRevoked, TokenClaimsChange, CredentialChange,
     AssuranceLevelChange, DeviceComplianceChange,
     AccountDisabled, AccountEnabled, AccountPurged, IdentifierChanged,
-    IdentifierRecycled, OptIn, OptOutCancelled, OptOutEffective,
-    OptOutInitiated, RISCSessionsRevoked, RecoveryActivated,
+    IdentifierRecycled, CredentialCompromise, OptIn, OptOutCancelled,
+    OptOutEffective, OptOutInitiated, RecoveryActivated,
     RecoveryInformationChanged
 )
 from swagger_server.models import (
@@ -29,20 +29,20 @@ event_type_map = {
     EventType.account_enabled: AccountEnabled,
     EventType.identifier_changed: IdentifierChanged,
     EventType.identifier_recycled: IdentifierRecycled,
+    EventType.credential_compromise: CredentialCompromise,
     EventType.opt_in: OptIn,
     EventType.opt_out_initiated: OptOutInitiated,
     EventType.opt_out_cancelled: OptOutCancelled,
     EventType.opt_out_effective: OptOutEffective,
     EventType.recovery_activated: RecoveryActivated,
     EventType.recovery_information_changed: RecoveryInformationChanged,
-    EventType.RISC_sessions_revoked: RISCSessionsRevoked,
 }
 
 
 def generate_security_event(event_type: EventType,
                             subject: Subject) -> SecurityEvent:
     event_class = event_type_map[event_type]
-    event_attribute_name = event_type.value.replace("-", "_")
+    event_attribute_name = event_type.name
     security_event = {
         "events": {
             event_attribute_name: event_class(subject=subject),

--- a/examples/transmitter/swagger_server/business_logic/stream.py
+++ b/examples/transmitter/swagger_server/business_logic/stream.py
@@ -194,8 +194,9 @@ class Stream:
         if SET.events.verification is not None:
             raise ValueError("Cannot broadcast Verification Events")
 
-        # assume this is a session revoked SET (the only other one we support)
-        # TODO: change this to support all CAEP and RISC
+        # TODO: Is there a better way than using this huge ladder?
+        # Supports all CAEP and RISC
+        # CAEP
         if SET.events.session_revoked:
             subject = SET.events.session_revoked.subject
         elif SET.events.token_claims_change:
@@ -206,9 +207,37 @@ class Stream:
             subject = SET.events.assurance_level_change.subject
         elif SET.events.device_compliance_change:
             subject = SET.events.device_compliance_change.subject
+        # RISC
+        elif SET.events.account_credential_change_required:
+            subject = SET.events.account_credential_change_required.subject
+        elif SET.events.account_purged:
+            subject = SET.events.account_purged.subject
+        elif SET.events.account_disabled:
+            subject = SET.events.account_disabled.subject
+        elif SET.events.account_enabled:
+            subject = SET.events.account_enabled.subject
+        elif SET.events.identifier_changed:
+            subject = SET.events.identifier_changed.subject
+        elif SET.events.identifier_recycled:
+            subject = SET.events.identifier_recycled.subject
+        elif SET.events.opt_in:
+            subject = SET.events.opt_in.subject
+        elif SET.events.opt_out_initiated:
+            subject = SET.events.opt_out_initiated.subject
+        elif SET.events.opt_out_cancelled:
+            subject = SET.events.opt_out_cancelled.subject
+        elif SET.events.opt_out_effective:
+            subject = SET.events.opt_out_effective.subject
+        elif SET.events.recovery_activated:
+            subject = SET.events.recovery_activated.subject
+        elif SET.events.recovery_information_changed:
+            subject = SET.events.recovery_information_changed.subject
+        elif SET.events.RISC_sessions_revoked:
+            subject = SET.events.RISC_sessions_revoked.subject
         else:
             # handle error
             subject = Subject()
+            logging.error(f"subject empty for given event")
 
         simple_subj = get_simple_subject(subject, Email)
         if not simple_subj:

--- a/examples/transmitter/swagger_server/business_logic/stream.py
+++ b/examples/transmitter/swagger_server/business_logic/stream.py
@@ -194,50 +194,11 @@ class Stream:
         if SET.events.verification is not None:
             raise ValueError("Cannot broadcast Verification Events")
 
-        # TODO: Is there a better way than using this huge ladder?
         # Supports all CAEP and RISC
-        # CAEP
-        if SET.events.session_revoked:
-            subject = SET.events.session_revoked.subject
-        elif SET.events.token_claims_change:
-            subject = SET.events.token_claims_change.subject
-        elif SET.events.credential_change:
-            subject = SET.events.credential_change.subject
-        elif SET.events.assurance_level_change:
-            subject = SET.events.assurance_level_change.subject
-        elif SET.events.device_compliance_change:
-            subject = SET.events.device_compliance_change.subject
-        # RISC
-        elif SET.events.account_credential_change_required:
-            subject = SET.events.account_credential_change_required.subject
-        elif SET.events.account_purged:
-            subject = SET.events.account_purged.subject
-        elif SET.events.account_disabled:
-            subject = SET.events.account_disabled.subject
-        elif SET.events.account_enabled:
-            subject = SET.events.account_enabled.subject
-        elif SET.events.identifier_changed:
-            subject = SET.events.identifier_changed.subject
-        elif SET.events.identifier_recycled:
-            subject = SET.events.identifier_recycled.subject
-        elif SET.events.opt_in:
-            subject = SET.events.opt_in.subject
-        elif SET.events.opt_out_initiated:
-            subject = SET.events.opt_out_initiated.subject
-        elif SET.events.opt_out_cancelled:
-            subject = SET.events.opt_out_cancelled.subject
-        elif SET.events.opt_out_effective:
-            subject = SET.events.opt_out_effective.subject
-        elif SET.events.recovery_activated:
-            subject = SET.events.recovery_activated.subject
-        elif SET.events.recovery_information_changed:
-            subject = SET.events.recovery_information_changed.subject
-        elif SET.events.RISC_sessions_revoked:
-            subject = SET.events.RISC_sessions_revoked.subject
-        else:
-            # handle error
-            subject = Subject()
+        subject = SET.events.get_subject()
+        if not subject:
             logging.error(f"subject empty for given event")
+            raise EmailSubjectNotFound(subject)
 
         simple_subj = get_simple_subject(subject, Email)
         if not simple_subj:

--- a/examples/transmitter/swagger_server/business_logic/stream.py
+++ b/examples/transmitter/swagger_server/business_logic/stream.py
@@ -53,7 +53,7 @@ class Stream:
                  status: Status = Status.enabled,
                  save: bool = True) -> None:
         self.client_id = client_id
-        self.config = DEFAULT_CONFIG.copy(update={ 'aud': aud })
+        self.config = DEFAULT_CONFIG.copy(update={'aud': aud})
         self.status = status
 
         if save:
@@ -83,18 +83,22 @@ class Stream:
         return new_stream
 
     def delete(self) -> None:
-        """Wipe out any subjects or SETs and revert the config to the default"""
+        """
+        Wipe out any subjects or SETs and
+        revert the config to the default
+        """
         db.delete_SETs(self.client_id)
         db.delete_subjects(self.client_id)
 
         # revert the stream to the default config
         audience = self.config.aud
         self.config = DEFAULT_CONFIG.copy(
-            update={ 'aud': audience }
+            update={'aud': audience}
         )
         self.save()
 
-    def update_config(self, new_config: StreamConfiguration, save: bool=True) -> Stream:
+    def update_config(self, new_config: StreamConfiguration,
+                      save: bool = True) -> Stream:
         config = self.config.dict()
         _new_config = new_config.dict()
 
@@ -147,7 +151,8 @@ class Stream:
         }
 
         if self.config.delivery.authorization_header:
-            headers["Authorization"] = self.config.delivery.authorization_header
+            headers["Authorization"] = \
+                self.config.delivery.authorization_header
 
         try:
             response = requests.post(
@@ -172,7 +177,8 @@ class Stream:
     def queue_SET(self, SET: SecurityEvent) -> None:
         db.add_set(self.client_id, SET)
 
-    def get_SETs(self, max_events: Optional[int]=None) -> List[SecurityEvent]:
+    def get_SETs(self,
+                 max_events: Optional[int] = None) -> List[SecurityEvent]:
         return db.get_SETs(self.client_id, max_events)
 
     def count_SETs(self) -> int:
@@ -202,7 +208,7 @@ class Stream:
             subject = SET.events.device_compliance_change.subject
         else:
             # handle error
-             subject = Subject()
+            subject = Subject()
 
         simple_subj = get_simple_subject(subject, Email)
         if not simple_subj:

--- a/examples/transmitter/swagger_server/controllers/__init__.py
+++ b/examples/transmitter/swagger_server/controllers/__init__.py
@@ -2,4 +2,3 @@
 # All rights reserved.
 # Use of this source code is governed by a BSD 3-Clause License
 # that can be found in the LICENSE file.
-

--- a/examples/transmitter/swagger_server/controllers/out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/controllers/out_of_band_controller.py
@@ -22,8 +22,10 @@ def register() -> Tuple[Dict[str, str], int]:
     token_json = business_logic.register(aud)
     return token_json, 200
 
+
 def trigger_event() -> Tuple[Any, int]:
     body = TriggerEventParameters.parse_obj(connexion.request.get_json())
 
-    business_logic.trigger_event(event_type=body.event_type,subject=body.subject)
+    business_logic.trigger_event(event_type=body.event_type,
+                                 subject=body.subject)
     return NoContent, 200

--- a/examples/transmitter/swagger_server/controllers/out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/controllers/out_of_band_controller.py
@@ -6,9 +6,10 @@
 from typing import Dict, Any, Tuple, Union, List
 
 import connexion
+from connexion import NoContent
 
 from swagger_server import business_logic
-from swagger_server.models import RegisterParameters
+from swagger_server.models import RegisterParameters, TriggerEventParameters
 
 
 def register() -> Tuple[Dict[str, str], int]:
@@ -20,3 +21,9 @@ def register() -> Tuple[Dict[str, str], int]:
 
     token_json = business_logic.register(aud)
     return token_json, 200
+
+def trigger_event() -> Tuple[Any, int]:
+    body = TriggerEventParameters.parse_obj(connexion.request.get_json())
+
+    business_logic.trigger_event(event_type=body.event_type,subject=body.subject)
+    return NoContent, 200

--- a/examples/transmitter/swagger_server/controllers/stream_management_controller.py
+++ b/examples/transmitter/swagger_server/controllers/stream_management_controller.py
@@ -44,12 +44,13 @@ def get_status(token_info: Dict[str, str],
     [Spec](https://openid.net/specs/openid-sse-framework-1_0.html#reading-a-streams-status)  An Event Receiver checks the current status of an event stream by making an HTTP GET request to the stream’s Status Endpoint. # noqa: E50
     """
     client_id = token_info['client_id']
-    
+
     subject_parsed = None
     if subject:
         subject_parsed = Subject.parse_raw(subject)
 
-    return business_logic.get_status(subject=subject_parsed, client_id=client_id), 200
+    return business_logic.get_status(subject=subject_parsed,
+                                     client_id=client_id), 200
 
 
 def remove_subject(token_info: Dict[str, str]) -> Tuple[Any, int]:  # noqa: E501

--- a/examples/transmitter/swagger_server/db.py
+++ b/examples/transmitter/swagger_server/db.py
@@ -133,13 +133,12 @@ def set_subject_status(client_id: str, email: str, status: Status) -> None:
         with conn:
             conn.execute("""
                 UPDATE subjects
-                SET 
+                SET
                     status = ?
                 WHERE
                     client_id = ? AND
                     email = ?
-                """,
-                (status.value, client_id, email)
+                """, (status.value, client_id, email)
             )
         if conn.total_changes != 1:
             raise SubjectNotInStream(email)
@@ -189,7 +188,7 @@ def add_set(client_id: str, SET: SecurityEvent) -> None:
             )
 
 
-def delete_SETs(client_id: str, jtis: Optional[List[str]]=None) -> None:
+def delete_SETs(client_id: str, jtis: Optional[List[str]] = None) -> None:
     """Delete SETs from the stream, based on their jtis"""
     sql = "DELETE FROM SETs WHERE client_id=?"
     if jtis:
@@ -210,7 +209,8 @@ def count_SETs(client_id: str) -> int:
         ).fetchone()[0]
 
 
-def get_SETs(client_id: str, max_events: Optional[int]=None) -> List[SecurityEvent]:
+def get_SETs(client_id: str,
+             max_events: Optional[int] = None) -> List[SecurityEvent]:
     """Get up to max_events SETs from the stream"""
     if max_events is not None and max_events <= 0:
         return []

--- a/examples/transmitter/swagger_server/events.py
+++ b/examples/transmitter/swagger_server/events.py
@@ -34,12 +34,11 @@ class CAEPEvent(Event):
 
 class SessionRevoked(CAEPEvent):
     pass
-    # CAEPEvent.__uri__ += "session-revoked"
-    # initiating_entity: str
+    
     
 class TokenClaimsChange(CAEPEvent):
     claims: Dict[str, str]
-    # CAEPEvent.__uri__ += "token-claims-change"
+
 
 class CredentialChange(CAEPEvent):
     credential_type: str
@@ -48,19 +47,17 @@ class CredentialChange(CAEPEvent):
     x509_issuer: Optional[str]
     x509_serial: Optional[str]
     fido2_aaguid: Optional[str]
-    # CAEPEvent.__uri__ +=  ""
         
 
 class AssuranceLevelChange(CAEPEvent):
     current_level: str
     previous_level: str
     change_direction: str
-    # CAEPEvent.__uri__ += "assurance-level-change"
+
     
 class DeviceComplianceChange(CAEPEvent):
     current_status: str
     previous_status: str
-    # CAEPEvent.__uri__ += "device-compliance-change"
 
 
 class Events(BaseModel):

--- a/examples/transmitter/swagger_server/events.py
+++ b/examples/transmitter/swagger_server/events.py
@@ -12,9 +12,10 @@ from pydantic import AnyUrl, BaseModel, Field
 from swagger_server.models import Subject
 
 CAEP_BASE_URI = "https://schemas.openid.net/secevent/caep/event-type"
-
+RISC_BASE_URI = "https://schemas.openid.net/secevent/risc/event-type"
 
 # Enums
+
 
 class AssuranceLevel(Enum):
     nist_aal1 = 'nist-aal1'
@@ -52,6 +53,11 @@ class DeviceStatus(Enum):
     not_compliant = 'not-compliant'
 
 
+class AccountDisabledReason(Enum):
+    hijacking = 'hijacking'
+    bulk_account = 'bulk-account'
+
+
 # Models
 
 class Event(BaseModel):
@@ -64,6 +70,65 @@ class Event(BaseModel):
 class VerificationEvent(Event):
     __uri__ = "https://schemas.openid.net/secevent/sse/event-type/verification"
     state: Optional[str]
+
+
+class RISCEvent(Event):
+    subject: Subject
+
+
+class AccountCredentialChangeRequired(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/account-credential-change-required"
+
+
+class AccountPurged(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/account-purged"
+
+
+class AccountDisabled(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/account-disabled"
+    # optional and enum
+    reason: Optional[AccountDisabledReason] = AccountDisabledReason.hijacking
+
+
+class AccountEnabled(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/account-enabled"
+
+
+class IdentifierChanged(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/identifier-changed"
+    new_value: Optional[str]  # optional and string?
+
+
+class IdentifierRecycled(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/identifier-recycled"
+
+
+class OptIn(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/opt-in"
+
+
+class OptOutInitiated(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/opt-out-initiated"
+
+
+class OptOutCancelled(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/opt-out-cancelled"
+
+
+class OptOutEffective(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/opt-out-effective"
+
+
+class RecoveryActivated(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/recovery-activated"
+
+
+class RecoveryInformationChanged(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/recovery-information-changed"
+
+
+class RISCSessionsRevoked(RISCEvent):
+    __uri__ = f"{RISC_BASE_URI}/sessions-revoked"
 
 
 class CAEPEvent(Event):
@@ -132,6 +197,34 @@ class Events(BaseModel):
     device_compliance_change: Optional[DeviceComplianceChange] = Field(
         alias=DeviceComplianceChange.__uri__)
 
+    # RISC
+    account_credential_change_required: Optional[AccountCredentialChangeRequired] = Field(
+        alias=AccountCredentialChangeRequired.__uri__)
+    account_purged: Optional[AccountPurged] = Field(
+        alias=AccountPurged.__uri__)
+    account_disabled: Optional[AccountDisabled] = Field(
+        alias=AccountDisabled.__uri__)
+    account_enabled: Optional[AccountEnabled] = Field(
+        alias=AccountEnabled.__uri__)
+    identifier_changed: Optional[IdentifierChanged] = Field(
+        alias=IdentifierChanged.__uri__)
+    identifier_recycled: Optional[IdentifierRecycled] = Field(
+        alias=IdentifierRecycled.__uri__)
+    opt_in: Optional[OptIn] = Field(
+        alias=OptIn.__uri__)
+    opt_out_initiated: Optional[OptOutInitiated] = Field(
+        alias=OptOutInitiated.__uri__)
+    opt_out_cancelled: Optional[OptOutCancelled] = Field(
+        alias=OptOutCancelled.__uri__)
+    opt_out_effective: Optional[OptOutEffective] = Field(
+        alias=OptOutEffective.__uri__)
+    recovery_activated: Optional[RecoveryActivated] = Field(
+        alias=RecoveryActivated.__uri__)
+    recovery_information_changed: Optional[RecoveryInformationChanged] = Field(
+        alias=RecoveryInformationChanged.__uri__)
+    RISC_sessions_revoked: Optional[RISCSessionsRevoked] = Field(
+        alias=RISCSessionsRevoked.__uri__)
+
     class Config:
         allow_population_by_field_name = True
 
@@ -150,5 +243,18 @@ SUPPORTED_EVENTS = [
     TokenClaimsChange.__uri__,
     CredentialChange.__uri__,
     AssuranceLevelChange.__uri__,
-    DeviceComplianceChange.__uri__
+    DeviceComplianceChange.__uri__,
+    AccountCredentialChangeRequired.__uri__,
+    AccountPurged.__uri__,
+    AccountDisabled.__uri__,
+    AccountEnabled.__uri__,
+    IdentifierChanged.__uri__,
+    IdentifierRecycled.__uri__,
+    OptIn.__uri__,
+    OptOutInitiated.__uri__,
+    OptOutCancelled.__uri__,
+    OptOutEffective.__uri__,
+    RecoveryActivated.__uri__,
+    RecoveryInformationChanged.__uri__,
+    RISCSessionsRevoked.__uri__,
 ]

--- a/examples/transmitter/swagger_server/events.py
+++ b/examples/transmitter/swagger_server/events.py
@@ -29,10 +29,38 @@ class CAEPEvent(Event):
     initiating_entity: Optional[str]
     reason_admin: Optional[Dict[str, str]]
     reason_user: Optional[Dict[str, str]]
+    __uri__ = "https://schemas.openid.net/secevent/caep/event-type/"
 
 
 class SessionRevoked(CAEPEvent):
-    __uri__ = "https://schemas.openid.net/secevent/caep/event-type/session-revoked"
+    pass
+    # CAEPEvent.__uri__ += "session-revoked"
+    # initiating_entity: str
+    
+class TokenClaimsChange(CAEPEvent):
+    claims: Dict[str, str]
+    # CAEPEvent.__uri__ += "token-claims-change"
+
+class CredentialChange(CAEPEvent):
+    credential_type: str
+    change_type: str
+    friendly_name: Optional[str]
+    x509_issuer: Optional[str]
+    x509_serial: Optional[str]
+    fido2_aaguid: Optional[str]
+    # CAEPEvent.__uri__ +=  ""
+        
+
+class AssuranceLevelChange(CAEPEvent):
+    current_level: str
+    previous_level: str
+    change_direction: str
+    # CAEPEvent.__uri__ += "assurance-level-change"
+    
+class DeviceComplianceChange(CAEPEvent):
+    current_status: str
+    previous_status: str
+    # CAEPEvent.__uri__ += "device-compliance-change"
 
 
 class Events(BaseModel):
@@ -40,7 +68,13 @@ class Events(BaseModel):
     verification: Optional[VerificationEvent] = Field(alias=VerificationEvent.__uri__)
 
     # CAEP
-    session_revoked: Optional[SessionRevoked] = Field(alias=SessionRevoked.__uri__)
+    CAEP_event: Optional[CAEPEvent] = Field(alias=CAEPEvent.__uri__)
+    session_revoked: Optional[SessionRevoked] = Field(alias=CAEPEvent.__uri__+"session-revoked")
+    token_claims_change: Optional[TokenClaimsChange] = Field(alias=CAEPEvent.__uri__+"token-claims-change")
+    credential_change: Optional[CredentialChange] = Field(alias=CAEPEvent.__uri__+"credential-change")
+    assurance_level_change: Optional[AssuranceLevelChange] = Field(alias=CAEPEvent.__uri__+"assurance-level-change")
+    device_compliance_change: Optional[DeviceComplianceChange] = Field(alias=CAEPEvent.__uri__+"device-compliance-change")
+    
 
     class Config:
         allow_population_by_field_name = True
@@ -56,5 +90,9 @@ class SecurityEvent(BaseModel):
 
 SUPPORTED_EVENTS = [
     VerificationEvent.__uri__,
-    SessionRevoked.__uri__
+    CAEPEvent.__uri__+"session-revoked",
+    CAEPEvent.__uri__+"token-claims-change",
+    CAEPEvent.__uri__+"credential-change",
+    CAEPEvent.__uri__+"assurance-level-change",
+    CAEPEvent.__uri__+"device-compliance-change"
 ]

--- a/examples/transmitter/swagger_server/events.py
+++ b/examples/transmitter/swagger_server/events.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # Use of this source code is governed by a BSD 3-Clause License
 # that can be found in the LICENSE file.
+from enum import Enum
 import time
 from typing import ClassVar, Dict, Optional
 import uuid
@@ -10,6 +11,48 @@ from pydantic import AnyUrl, BaseModel, Field
 
 from swagger_server.models import Subject
 
+CAEP_BASE_URI = "https://schemas.openid.net/secevent/caep/event-type"
+
+
+# Enums
+
+class AssuranceLevels(Enum):
+    nist_aal1 = 'nist-aal1'
+    nist_aal2 = 'nist-aal2'
+    nist_aal3 = 'nist-aal3'
+
+
+class AssuranceDirections(Enum):
+    increase = 'increase'
+    decrease = 'decrease'
+
+
+class CredentialChangeTypes(Enum):
+    create = 'create'
+    revoke = 'revoke'
+    update = 'update'
+    delete = 'delete'
+
+
+class CredentialTypes(Enum):
+    password = 'password'
+    pin = 'pin'
+    x509 = 'x509'
+    fido2_platform = 'fido2-platform'
+    fido2_roaming = 'fido2-roaming'
+    fido_u2f = 'fido-u2f'
+    verifiable_credential = 'verifiable-credential'
+    phone_voice = 'phone-voice'
+    phone_sms = 'phone-sms'
+    app = 'app'
+
+
+class DeviceStatuses(Enum):
+    compliant = 'compliant'
+    not_compliant = 'not-compliant'
+
+
+# Models
 
 class Event(BaseModel):
     __uri__: ClassVar[AnyUrl]
@@ -24,54 +67,70 @@ class VerificationEvent(Event):
 
 
 class CAEPEvent(Event):
+    # use this, can't use init
+    # https://stackoverflow.com/questions/63616798/
+    # pydantic-how-to-pass-the-default-value-to-a-variable-if-none-was-passed
     subject: Subject
-    event_timestamp: Optional[int]
-    initiating_entity: Optional[str]
+    event_timestamp: Optional[int] = Field(
+        default_factory=lambda: int(time.time()))
+    initiating_entity: Optional[str] = 'Duo policy'
     reason_admin: Optional[Dict[str, str]]
     reason_user: Optional[Dict[str, str]]
-    __uri__ = "https://schemas.openid.net/secevent/caep/event-type/"
 
 
 class SessionRevoked(CAEPEvent):
-    pass
-    
-    
+    # class variable shared by all instances
+    __uri__ = f"{CAEP_BASE_URI}/session-revoked"
+
+
 class TokenClaimsChange(CAEPEvent):
-    claims: Dict[str, str]
+    # class variable shared by all instances
+    __uri__ = f"{CAEP_BASE_URI}/token-claims-change"
+    claims: Dict[str, str] = {"trusted_network": "false"}
 
 
 class CredentialChange(CAEPEvent):
-    credential_type: str
-    change_type: str
+    # class variable shared by all instances
+    __uri__ = f"{CAEP_BASE_URI}/credential-change"
+    credential_type: CredentialTypes = CredentialTypes.fido2_roaming
+    change_type: CredentialChangeTypes = CredentialChangeTypes.create
     friendly_name: Optional[str]
     x509_issuer: Optional[str]
     x509_serial: Optional[str]
     fido2_aaguid: Optional[str]
-        
+
 
 class AssuranceLevelChange(CAEPEvent):
-    current_level: str
-    previous_level: str
-    change_direction: str
+    # class variable shared by all instances
+    __uri__ = f"{CAEP_BASE_URI}/assurance-level-change"
+    current_level: AssuranceLevels = AssuranceLevels.nist_aal2
+    previous_level: AssuranceLevels = AssuranceLevels.nist_aal1
+    change_direction: AssuranceDirections = AssuranceDirections.increase
 
-    
+
 class DeviceComplianceChange(CAEPEvent):
-    current_status: str
-    previous_status: str
+    # class variable shared by all instances
+    __uri__ = f"{CAEP_BASE_URI}/device-compliance-change"
+    current_status: DeviceStatuses = DeviceStatuses.compliant
+    previous_status: DeviceStatuses = DeviceStatuses.not_compliant
 
 
 class Events(BaseModel):
     # SSE
-    verification: Optional[VerificationEvent] = Field(alias=VerificationEvent.__uri__)
+    verification: Optional[VerificationEvent] = Field(
+        alias=VerificationEvent.__uri__)
 
     # CAEP
-    CAEP_event: Optional[CAEPEvent] = Field(alias=CAEPEvent.__uri__)
-    session_revoked: Optional[SessionRevoked] = Field(alias=CAEPEvent.__uri__+"session-revoked")
-    token_claims_change: Optional[TokenClaimsChange] = Field(alias=CAEPEvent.__uri__+"token-claims-change")
-    credential_change: Optional[CredentialChange] = Field(alias=CAEPEvent.__uri__+"credential-change")
-    assurance_level_change: Optional[AssuranceLevelChange] = Field(alias=CAEPEvent.__uri__+"assurance-level-change")
-    device_compliance_change: Optional[DeviceComplianceChange] = Field(alias=CAEPEvent.__uri__+"device-compliance-change")
-    
+    session_revoked: Optional[SessionRevoked] = Field(
+        alias=SessionRevoked.__uri__)
+    token_claims_change: Optional[TokenClaimsChange] = Field(
+        alias=TokenClaimsChange.__uri__)
+    credential_change: Optional[CredentialChange] = Field(
+        alias=CredentialChange.__uri__)
+    assurance_level_change: Optional[AssuranceLevelChange] = Field(
+        alias=AssuranceLevelChange.__uri__)
+    device_compliance_change: Optional[DeviceComplianceChange] = Field(
+        alias=DeviceComplianceChange.__uri__)
 
     class Config:
         allow_population_by_field_name = True
@@ -87,9 +146,9 @@ class SecurityEvent(BaseModel):
 
 SUPPORTED_EVENTS = [
     VerificationEvent.__uri__,
-    CAEPEvent.__uri__+"session-revoked",
-    CAEPEvent.__uri__+"token-claims-change",
-    CAEPEvent.__uri__+"credential-change",
-    CAEPEvent.__uri__+"assurance-level-change",
-    CAEPEvent.__uri__+"device-compliance-change"
+    SessionRevoked.__uri__,
+    TokenClaimsChange.__uri__,
+    CredentialChange.__uri__,
+    AssuranceLevelChange.__uri__,
+    DeviceComplianceChange.__uri__
 ]

--- a/examples/transmitter/swagger_server/events.py
+++ b/examples/transmitter/swagger_server/events.py
@@ -16,25 +16,25 @@ CAEP_BASE_URI = "https://schemas.openid.net/secevent/caep/event-type"
 
 # Enums
 
-class AssuranceLevels(Enum):
+class AssuranceLevel(Enum):
     nist_aal1 = 'nist-aal1'
     nist_aal2 = 'nist-aal2'
     nist_aal3 = 'nist-aal3'
 
 
-class AssuranceDirections(Enum):
+class AssuranceDirection(Enum):
     increase = 'increase'
     decrease = 'decrease'
 
 
-class CredentialChangeTypes(Enum):
+class CredentialChangeType(Enum):
     create = 'create'
     revoke = 'revoke'
     update = 'update'
     delete = 'delete'
 
 
-class CredentialTypes(Enum):
+class CredentialType(Enum):
     password = 'password'
     pin = 'pin'
     x509 = 'x509'
@@ -47,7 +47,7 @@ class CredentialTypes(Enum):
     app = 'app'
 
 
-class DeviceStatuses(Enum):
+class DeviceStatus(Enum):
     compliant = 'compliant'
     not_compliant = 'not-compliant'
 
@@ -92,8 +92,8 @@ class TokenClaimsChange(CAEPEvent):
 class CredentialChange(CAEPEvent):
     # class variable shared by all instances
     __uri__ = f"{CAEP_BASE_URI}/credential-change"
-    credential_type: CredentialTypes = CredentialTypes.fido2_roaming
-    change_type: CredentialChangeTypes = CredentialChangeTypes.create
+    credential_type: CredentialType = CredentialType.fido2_roaming
+    change_type: CredentialChangeType = CredentialChangeType.create
     friendly_name: Optional[str]
     x509_issuer: Optional[str]
     x509_serial: Optional[str]
@@ -103,16 +103,16 @@ class CredentialChange(CAEPEvent):
 class AssuranceLevelChange(CAEPEvent):
     # class variable shared by all instances
     __uri__ = f"{CAEP_BASE_URI}/assurance-level-change"
-    current_level: AssuranceLevels = AssuranceLevels.nist_aal2
-    previous_level: AssuranceLevels = AssuranceLevels.nist_aal1
-    change_direction: AssuranceDirections = AssuranceDirections.increase
+    current_level: AssuranceLevel = AssuranceLevel.nist_aal2
+    previous_level: AssuranceLevel = AssuranceLevel.nist_aal1
+    change_direction: AssuranceDirection = AssuranceDirection.increase
 
 
 class DeviceComplianceChange(CAEPEvent):
     # class variable shared by all instances
     __uri__ = f"{CAEP_BASE_URI}/device-compliance-change"
-    current_status: DeviceStatuses = DeviceStatuses.compliant
-    previous_status: DeviceStatuses = DeviceStatuses.not_compliant
+    current_status: DeviceStatus = DeviceStatus.compliant
+    previous_status: DeviceStatus = DeviceStatus.not_compliant
 
 
 class Events(BaseModel):

--- a/examples/transmitter/swagger_server/jwt_encode.py
+++ b/examples/transmitter/swagger_server/jwt_encode.py
@@ -86,7 +86,8 @@ def encode_set(security_event_token: SecurityEvent) -> str:
         algorithm=jwk.alg,
         headers=dict(
             kid=key_id,
-            typ="secevent+jwt"  # https://www.rfc-editor.org/rfc/rfc8417.html#section-2.3
+            typ="secevent+jwt"
+            # https://www.rfc-editor.org/rfc/rfc8417.html#section-2.3
         ),
         json_encoder=JSONEncoder
     )

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -471,7 +471,7 @@ class TriggerEventParameters(BaseModel):
 
     event_type: str = Field(
         ...,
-        description='Read-Write.\nSupports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.      ',
+        description='Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
         example='credential-compromise',
     )
     subject: Subject

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -127,6 +127,18 @@ class RegisterResponse(BaseModel):
     )
 
 
+class EventType(Enum):
+    """
+    Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
+    """
+
+    session_revoked = 'session-revoked'
+    token_claims_change = 'token-claims-change'
+    credential_change = 'credential-change'
+    assurance_level_change = 'assurance-level-change'
+    device_compliance_change = 'device-compliance-change'
+
+
 class PollParameters(BaseModel):
     maxEvents: Optional[int] = Field(
         None,
@@ -469,7 +481,7 @@ class TriggerEventParameters(BaseModel):
 
     """
 
-    event_type: str = Field(
+    event_type: EventType = Field(
         ...,
         description='Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
         example='credential-compromise',

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -463,6 +463,20 @@ class UpdateStreamStatus(StreamStatus):
     )
 
 
+class TriggerEventParameters(BaseModel):
+    """
+    JSON Object describing request to create a security event to test SSE receiver/transmitter
+
+    """
+
+    event_type: str = Field(
+        ...,
+        description='Read-Write.\nSupports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.      ',
+        example='credential-compromise',
+    )
+    subject: Subject
+
+
 class AddSubjectParameters(BaseModel):
     subject: Subject
     verified: Optional[bool] = Field(

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -129,7 +129,7 @@ class RegisterResponse(BaseModel):
 
 class EventType(Enum):
     """
-    Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
+    Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     """
 
     session_revoked = 'session-revoked'
@@ -142,13 +142,13 @@ class EventType(Enum):
     account_enabled = 'account-enabled'
     identifier_changed = 'identifier-changed'
     identifier_recycled = 'identifier-recycled'
+    credential_compromise = 'credential-compromise'
     opt_in = 'opt-in'
     opt_out_initiated = 'opt-out-initiated'
     opt_out_cancelled = 'opt-out-cancelled'
     opt_out_effective = 'opt-out-effective'
     recovery_activated = 'recovery-activated'
     recovery_information_changed = 'recovery-information-changed'
-    RISC_sessions_revoked = 'RISC-sessions-revoked'
 
 
 class PollParameters(BaseModel):
@@ -495,7 +495,7 @@ class TriggerEventParameters(BaseModel):
 
     event_type: EventType = Field(
         ...,
-        description='Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
+        description='Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
         example='credential-compromise',
     )
     subject: Subject

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -137,6 +137,18 @@ class EventType(Enum):
     credential_change = 'credential-change'
     assurance_level_change = 'assurance-level-change'
     device_compliance_change = 'device-compliance-change'
+    account_purged = 'account-purged'
+    account_disabled = 'account-disabled'
+    account_enabled = 'account-enabled'
+    identifier_changed = 'identifier-changed'
+    identifier_recycled = 'identifier-recycled'
+    opt_in = 'opt-in'
+    opt_out_initiated = 'opt-out-initiated'
+    opt_out_cancelled = 'opt-out-cancelled'
+    opt_out_effective = 'opt-out-effective'
+    recovery_activated = 'recovery-activated'
+    recovery_information_changed = 'recovery-information-changed'
+    RISC_sessions_revoked = 'RISC-sessions-revoked'
 
 
 class PollParameters(BaseModel):

--- a/examples/transmitter/swagger_server/models.py
+++ b/examples/transmitter/swagger_server/models.py
@@ -129,7 +129,7 @@ class RegisterResponse(BaseModel):
 
 class EventType(Enum):
     """
-    Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
+    Supports all [RISC](https://openid.net/specs/openid-risc-profile-specification-1_0-01.html) and [CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     """
 
     session_revoked = 'session-revoked'
@@ -495,7 +495,7 @@ class TriggerEventParameters(BaseModel):
 
     event_type: EventType = Field(
         ...,
-        description='Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
+        description='Supports all [RISC](https://openid.net/specs/openid-risc-profile-specification-1_0-01.html) and [CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.',
         example='credential-compromise',
     )
     subject: Subject

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -869,15 +869,17 @@ components:
       properties:
         event_type:
           type: string
-          description: "Read-Write.\nSupports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)\
+          description: "Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)\
             \ and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
-            \ event types.      "
+            \ event types."
           example: credential-compromise
         subject:
           allOf:
           - $ref: '#/components/schemas/Subject'
-          - description: REQUIRED. SHOULD be same as subjects receiver cares about
-              (config.cfg). A Subject claim identifying the subject to be added.
+          - description: |
+              REQUIRED. ONLY EMAIL format supported currently.
+              SHOULD be same as subjects receiver cares about.
+              A Subject claim identifying the subject of the event to be generated.
       description: "JSON Object describing request to create a security event to test\
         \ SSE receiver/transmitter \n"
       example:

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -544,6 +544,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterResponse'
       x-openapi-router-controller: swagger_server.controllers.out_of_band_controller
+  /trigger-event:
+    post:
+      tags:
+      - OutOfBand
+      summary: Request the transmitter to create a SSE event of certain type and subject
+        and send it to the (streams)receivers that care about the subject.
+      description: "This endpoint is not part of the spec, but rather a quick-and-dirty\
+        \ way to  test out sample security events other than verification."
+      operationId: trigger_event
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerEventParameters'
+        required: true
+      responses:
+        "200":
+          description: "On successful creation of an event, it will be sent out as\
+            \ per SSE spec (i.e. push or poll)."
+      x-openapi-router-controller: swagger_server.controllers.out_of_band_controller
 components:
   schemas:
     StreamStatus:
@@ -840,6 +860,31 @@ components:
             Stream Management API calls that require authorization.
       example:
         token: 49e5e7785e4e4f688aa49e2585970370
+    TriggerEventParameters:
+      title: Trigger Event Parameters
+      required:
+      - event_type
+      - subject
+      type: object
+      properties:
+        event_type:
+          type: string
+          description: "Read-Write.\nSupports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)\
+            \ and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
+            \ event types.      "
+          example: credential-compromise
+        subject:
+          allOf:
+          - $ref: '#/components/schemas/Subject'
+          - description: REQUIRED. SHOULD be same as subjects receiver cares about
+              (config.cfg). A Subject claim identifying the subject to be added.
+      description: "JSON Object describing request to create a security event to test\
+        \ SSE receiver/transmitter \n"
+      example:
+        event_type: session-revoked
+        subject:
+          format: email
+          email: user@example.com
     AddSubjectParameters:
       required:
       - subject

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -869,8 +869,8 @@ components:
       properties:
         event_type:
           type: string
-          description: "Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html)\
-            \ and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
+          description: "Supports all [RISC](https://openid.net/specs/openid-risc-profile-specification-1_0-01.html)\
+            \ and [CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
             \ event types."
           example: credential-compromise
           enum:

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -879,6 +879,18 @@ components:
           - credential-change
           - assurance-level-change
           - device-compliance-change
+          - account-purged
+          - account-disabled
+          - account-enabled
+          - identifier-changed
+          - identifier-recycled
+          - opt-in
+          - opt-out-initiated
+          - opt-out-cancelled
+          - opt-out-effective
+          - recovery-activated
+          - recovery-information-changed
+          - RISC-sessions-revoked
         subject:
           allOf:
           - $ref: '#/components/schemas/Subject'

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -869,7 +869,7 @@ components:
       properties:
         event_type:
           type: string
-          description: "Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html)\
+          description: "Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html)\
             \ and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
             \ event types."
           example: credential-compromise
@@ -884,13 +884,13 @@ components:
           - account-enabled
           - identifier-changed
           - identifier-recycled
+          - credential-compromise
           - opt-in
           - opt-out-initiated
           - opt-out-cancelled
           - opt-out-effective
           - recovery-activated
           - recovery-information-changed
-          - RISC-sessions-revoked
         subject:
           allOf:
           - $ref: '#/components/schemas/Subject'

--- a/examples/transmitter/swagger_server/swagger/swagger.yaml
+++ b/examples/transmitter/swagger_server/swagger/swagger.yaml
@@ -873,6 +873,12 @@ components:
             \ and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html)\
             \ event types."
           example: credential-compromise
+          enum:
+          - session-revoked
+          - token-claims-change
+          - credential-change
+          - assurance-level-change
+          - device-compliance-change
         subject:
           allOf:
           - $ref: '#/components/schemas/Subject'

--- a/examples/transmitter/swagger_server/test/conftest.py
+++ b/examples/transmitter/swagger_server/test/conftest.py
@@ -32,7 +32,7 @@ def temp_db(monkeypatch, tmpdir) -> None:
 
 @pytest.fixture
 def client(temp_db) -> Iterator[FlaskClient]:
-    app = create_app({ 'TESTING': True })
+    app = create_app({'TESTING': True})
 
     with app.test_client() as client:
         yield client
@@ -56,7 +56,8 @@ def create_app(self) -> Flask:
 
 
 @pytest.fixture(autouse=True)
-def jwks_path(monkeypatch: MonkeyPatch, tmpdir: py.path.local) -> Iterator[str]:
+def jwks_path(monkeypatch: MonkeyPatch,
+              tmpdir: py.path.local) -> Iterator[str]:
     """Mock out the environment variables so that we have control over them
     for testing.
     """

--- a/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
@@ -38,7 +38,8 @@ def test_register(client: FlaskClient) -> None:
 @pytest.mark.parametrize("subject", [
     Subject.parse_obj({"user": {"format": "email", "email": "foo@bar.com"}}),
     Subject.parse_obj({"format": "email", "email": "foo@bar.com"}),
-    Subject.parse_obj({"identifiers": [{"format": "email", "email": "user@example.com"}]})
+    Subject.parse_obj({"identifiers": [{"format": "email",
+                                        "email": "user@example.com"}]})
 ])
 @pytest.mark.parametrize("event_type", [
     "session-revoked",
@@ -47,7 +48,8 @@ def test_register(client: FlaskClient) -> None:
     "assurance-level-change",
     "device-compliance-change"
 ])
-def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) -> None:
+def test_trigger_event(client: FlaskClient, subject: Subject,
+                       event_type: str) -> None:
     """Test case for trigger_event
 
     Request to generate a security event other than verification
@@ -62,12 +64,13 @@ def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) ->
     )
     register_response_json = json.loads(register_response.data.decode('utf-8'))
     assert db.stream_exists(register_response_json['token'])
-    
+
     # Set stream to poll
     new_config = StreamConfiguration(
         iss='http://pets.com',  # this should not update
         events_requested=[],
-        delivery=PollDeliveryMethod(endpoint_url="http://transmitter.com/polling"),
+        delivery=PollDeliveryMethod(
+            endpoint_url="http://transmitter.com/polling"),
         subject=subject
     )
 
@@ -78,7 +81,6 @@ def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) ->
     )
     assert_status_code(response, 200)
 
-    
     # add subject
     body = AddSubjectParameters(subject=subject, verified=False)
     response = client.post(
@@ -87,8 +89,7 @@ def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) ->
         headers={'Authorization': f'Bearer {register_response_json["token"]}'}
     )
     assert response.status_code == 200
-    
-    
+
     # trigger event
     body = TriggerEventParameters(
         event_type=event_type,
@@ -107,12 +108,14 @@ def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) ->
 @pytest.mark.parametrize("subject", [
     Subject.parse_obj({"user": {"format": "email", "email": "foo@bar.com"}}),
     Subject.parse_obj({"format": "email", "email": "foo@bar.com"}),
-    Subject.parse_obj({"identifiers": [{"format": "email", "email": "user@example.com"}]})
+    Subject.parse_obj({"identifiers": [{"format": "email",
+                                        "email": "user@example.com"}]})
 ])
 @pytest.mark.parametrize("event_type", [
     "invalid-event-type"
 ])
-def test_trigger_invalid_event(client: FlaskClient, subject: Subject, event_type:str) -> None:
+def test_trigger_invalid_event(client: FlaskClient, subject: Subject,
+                               event_type: str) -> None:
     """Test case for trigger_event
 
     Request to generate a security event other than verification

--- a/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
@@ -53,13 +53,13 @@ def test_register(client: FlaskClient) -> None:
     EventType.account_enabled,
     EventType.identifier_changed,
     EventType.identifier_recycled,
+    EventType.credential_compromise,
     EventType.opt_in,
     EventType.opt_out_initiated,
     EventType.opt_out_cancelled,
     EventType.opt_out_effective,
     EventType.recovery_activated,
     EventType.recovery_information_changed,
-    EventType.RISC_sessions_revoked
 ])
 def test_trigger_event(client: FlaskClient, subject: Subject,
                        event_type: EventType) -> None:

--- a/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
@@ -47,7 +47,19 @@ def test_register(client: FlaskClient) -> None:
     EventType.token_claims_change,
     EventType.credential_change,
     EventType.assurance_level_change,
-    EventType.device_compliance_change
+    EventType.device_compliance_change,
+    EventType.account_purged,
+    EventType.account_disabled,
+    EventType.account_enabled,
+    EventType.identifier_changed,
+    EventType.identifier_recycled,
+    EventType.opt_in,
+    EventType.opt_out_initiated,
+    EventType.opt_out_cancelled,
+    EventType.opt_out_effective,
+    EventType.recovery_activated,
+    EventType.recovery_information_changed,
+    EventType.RISC_sessions_revoked
 ])
 def test_trigger_event(client: FlaskClient, subject: Subject,
                        event_type: EventType) -> None:

--- a/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
+++ b/examples/transmitter/swagger_server/test/test_out_of_band_controller.py
@@ -7,8 +7,13 @@ import json
 
 from flask.testing import FlaskClient
 
+import pytest
+
 from swagger_server import db
-from swagger_server.models import RegisterParameters
+from swagger_server.models import (
+    RegisterParameters, Subject, TriggerEventParameters,
+    PollDeliveryMethod, StreamConfiguration
+)
 from swagger_server.test.conftest import assert_status_code
 
 
@@ -30,6 +35,85 @@ def test_register(client: FlaskClient) -> None:
     assert db.stream_exists(response_json['token'])
 
 
+@pytest.mark.parametrize("subject", [
+    Subject.parse_obj({"user": {"format": "email", "email": "foo@bar.com"}}),
+    Subject.parse_obj({"format": "email", "email": "foo@bar.com"}),
+    Subject.parse_obj({"identifiers": [{"format": "email", "email": "user@example.com"}]})
+])
+@pytest.mark.parametrize("event_type", [
+    "session-revoked",
+    "token-claims-change",
+    "credential-change",
+    "assurance-level-change",
+    "device-compliance-change"
+])
+def test_trigger_event(client: FlaskClient, subject: Subject, event_type:str) -> None:
+    """Test case for trigger_event
+
+    Request to generate a security event other than verification
+    """
+    # register a stream
+    body = RegisterParameters(
+        audience='https://popular-app.com'
+    )
+    register_response = client.post(
+        '/register',
+        json=body.dict(exclude_none=True)
+    )
+    register_response_json = json.loads(register_response.data.decode('utf-8'))
+    assert db.stream_exists(register_response_json['token'])
+    
+    # # Set stream to poll
+    # new_config = StreamConfiguration(
+    #     iss='http://pets.com',  # this should not update
+    #     events_requested=[],
+    #     delivery=PollDeliveryMethod(endpoint_url=None)
+    # )
+
+    # response = client.post(
+    #     '/stream',
+    #     json=new_config.dict(exclude_none=True),
+    #     headers={'Authorization': f'Bearer {register_response_json["token"]}'}
+    # )
+    
+    # trigger event
+    body = TriggerEventParameters(
+        event_type=event_type,
+        subject=subject
+    )
+    response = client.post(
+        '/trigger-event',
+        json=body
+    )
+    assert_status_code(response, 200)
+    # # check if event is queued
+    # num_SETs = db.count_SETs(register_response_json["token"])
+    # assert num_SETs
+
+
+@pytest.mark.parametrize("subject", [
+    Subject.parse_obj({"user": {"format": "email", "email": "foo@bar.com"}}),
+    Subject.parse_obj({"format": "email", "email": "foo@bar.com"}),
+    Subject.parse_obj({"identifiers": [{"format": "email", "email": "user@example.com"}]})
+])
+@pytest.mark.parametrize("event_type", [
+    "invalid-event-type"
+])
+def test_trigger_invalid_event(client: FlaskClient, subject: Subject, event_type:str) -> None:
+    """Test case for trigger_event
+
+    Request to generate a security event other than verification
+    """
+    body = TriggerEventParameters(
+        event_type=event_type,
+        subject=subject
+    )
+    response = client.post(
+        '/trigger-event',
+        json=body
+    )
+    assert_status_code(response, 500)
+
+
 if __name__ == '__main__':
-    import pytest
     pytest.main()

--- a/examples/transmitter/swagger_server/test/test_stream_management_controller.py
+++ b/examples/transmitter/swagger_server/test/test_stream_management_controller.py
@@ -212,11 +212,11 @@ def test_stream_post(client, new_stream: Stream) -> None:
     """
     old_config = new_stream.config.copy()
     requested_events = SUPPORTED_EVENTS.copy()
-    requested_events.pop()  # remove session revoked
     requested_events.append('https://schemas.openid.net/fake-event')
     new_config = StreamConfiguration(
         iss='http://pets.com',  # this should not update
-        events_requested=requested_events,
+        # request: [verification_event,fake_event]
+        events_requested=[requested_events[0],requested_events[-1]],
         delivery=PollDeliveryMethod(endpoint_url=None)
     )
 
@@ -233,11 +233,12 @@ def test_stream_post(client, new_stream: Stream) -> None:
     assert updated_stream.config.iss != new_config.iss
     assert updated_stream.config.aud == old_config.aud
     assert updated_stream.config.events_supported == old_config.events_supported
-    assert updated_stream.config.events_requested == requested_events
+    # check config update for requested events: [verification_event,fake_event]
+    assert updated_stream.config.events_requested == [requested_events[0],requested_events[-1]]
 
     expected_delivered = SUPPORTED_EVENTS.copy()
-    expected_delivered.pop()
-    assert updated_stream.config.events_delivered == expected_delivered
+    # check config update for events_delivered: [verification_event]
+    assert updated_stream.config.events_delivered == [expected_delivered[0]]
 
 
 def test_stream_post__no_stream(client: FlaskClient) -> None:

--- a/examples/transmitter/swagger_server/test/test_stream_management_controller.py
+++ b/examples/transmitter/swagger_server/test/test_stream_management_controller.py
@@ -433,11 +433,13 @@ def test_verification_request__polling(client: FlaskClient, new_stream: Stream,
         assert verification_event.state is None
 
 
-def test_verification_request__pushing__no_response(client: FlaskClient, new_stream: Stream) -> None:
+def test_verification_request__pushing__no_response(client: FlaskClient,
+                                                    new_stream: Stream) -> None:
     """Test case for verification_request
 
-    Request that a verification event be sent over an Event Stream with Push delivery method,
-    but the push delivery fails, the response to the request must still return 204
+    Request that a verification event be sent over an Event Stream with
+    Push delivery method, but the push delivery fails, the response to 
+    the request must still return 204
     """
     push_url = "https://test-case.popular-app.com/push"
     new_stream.config.delivery = PushDeliveryMethod(endpoint_url=push_url)

--- a/examples/transmitter/swagger_server/utils.py
+++ b/examples/transmitter/swagger_server/utils.py
@@ -5,40 +5,46 @@
 
 from typing import Optional, TypeVar, Type
 
-from swagger_server.models import (Subject, SimpleSubject, ComplexSubject, Aliases,
-                                   Account, DID, Email, IssSub, JwtID, Opaque,
-                                   PhoneNumber, SamlAssertionID)
+from swagger_server.models import (
+    Subject, SimpleSubject, ComplexSubject, Aliases,
+    Account, DID, Email, IssSub, JwtID, Opaque,
+    PhoneNumber, SamlAssertionID)
 
 
 SimpleSubjectType = TypeVar(
     'SimpleSubjectType',
     # TODO codegen this list somewhere with a custom template
-    # (the list must be static, thus we can't refer to SimpleSubject class at runtime)
-    Account, DID, Email, IssSub, JwtID, Opaque, PhoneNumber, SamlAssertionID,
+    # (the list must be static, thus we can't refer to
+    # SimpleSubject class at runtime)
+    Account, DID, Email, IssSub, JwtID, Opaque,
+    PhoneNumber, SamlAssertionID,
 )
 
 
-def get_simple_subject(subject: Subject, 
-                       simple_subj_type: Type[SimpleSubjectType]) -> Optional[SimpleSubjectType]:
+def get_simple_subject(subject: Subject,
+                       simple_subj_type:
+                       Type[SimpleSubjectType]) -> Optional[SimpleSubjectType]:
     subj_root = subject.__root__
     if isinstance(subj_root, SimpleSubject):
         # return the simplesubject as long as it matches simple_subj_type
         simple_subj = subj_root.__root__
-        return simple_subj if isinstance(simple_subj, simple_subj_type) else None
+        return simple_subj if isinstance(simple_subj,
+                                         simple_subj_type) else None
     elif isinstance(subj_root, Aliases):
-        # iterate through all identifiers, return the first that matches simple_subj_type
+        # iterate through all identifiers,
+        # return the first that matches simple_subj_type
         return next(
             (i.__root__ for
-            i in subj_root.identifiers
-            if isinstance(i.__root__, simple_subj_type)),
+                i in subj_root.identifiers
+                if isinstance(i.__root__, simple_subj_type)),
             None
         )
     elif isinstance(subj_root, ComplexSubject):
-        # iterate through all fields, return the first that matches simple_subj_type
+        # iterate through all fields,
+        # return the first that matches simple_subj_type
         return next(
-            (subj.__root__
-            for subj in vars(subj_root).values()
-            if subj and isinstance(subj.__root__, simple_subj_type)),
+            (subj.__root__ for subj in vars(subj_root).values()
+                if subj and isinstance(subj.__root__, simple_subj_type)),
             None
         )
     else:

--- a/transmitter_spec/openapi.yaml
+++ b/transmitter_spec/openapi.yaml
@@ -37,6 +37,8 @@ paths:
     $ref: './paths/poll.yaml'
   /register:
     $ref: './paths/register.yaml'
+  /trigger-event:
+    $ref: './paths/trigger-event.yaml'
 
 components:
   securitySchemes:
@@ -67,6 +69,8 @@ components:
 
     RegisterResponse:
       $ref: './schemas/RegisterResponse.yaml'
+    TriggerEventParameters:
+      $ref: './schemas/TriggerEventParameters.yaml'
 
     # Request Body params
     AddSubjectParameters:

--- a/transmitter_spec/paths/trigger-event.yaml
+++ b/transmitter_spec/paths/trigger-event.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+# Use of this source code is governed by a BSD 3-Clause License
+# that can be found in the LICENSE file.
+
+post:
+  tags:
+    - OutOfBand
+  summary: Request the transmitter to create a SSE event of certain type and subject and send it to the (streams)receivers that care about the subject.
+  description: |-
+    This endpoint is not part of the spec, but rather a quick-and-dirty way to  test out sample security events other than verification.
+  operationId: trigger_event
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/TriggerEventParameters"
+  responses:
+    200:
+      description: |-
+        On successful creation of an event, it will be sent out as per SSE spec (i.e. push or poll).

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -18,9 +18,9 @@ required:
 properties:
   event_type:
     type: string
-    enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, account-purged, account-disabled, account-enabled, identifier-changed, identifier-recycled, opt-in, opt-out-initiated, opt-out-cancelled, opt-out-effective, recovery-activated, recovery-information-changed, RISC-sessions-revoked]
+    enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, account-purged, account-disabled, account-enabled, identifier-changed, identifier-recycled, credential-compromise, opt-in, opt-out-initiated, opt-out-cancelled, opt-out-effective, recovery-activated, recovery-information-changed]
     description: |-
-      Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
+      Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     example: credential-compromise
   subject:
     allOf:

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -18,6 +18,7 @@ required:
 properties:
   event_type:
     type: string
+    enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change]
     description: |-
       Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     example: credential-compromise

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -19,10 +19,12 @@ properties:
   event_type:
     type: string
     description: |-
-      Read-Write.
-      Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.      
+      Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     example: credential-compromise
   subject:
     allOf:
       - $ref: "../openapi.yaml#/components/schemas/Subject"
-      - description: "REQUIRED. SHOULD be same as subjects receiver cares about (config.cfg). A Subject claim identifying the subject to be added."
+      - description: |
+          REQUIRED. ONLY EMAIL format supported currently.
+          SHOULD be same as subjects receiver cares about.
+          A Subject claim identifying the subject of the event to be generated.

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -20,7 +20,7 @@ properties:
     type: string
     enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, account-purged, account-disabled, account-enabled, identifier-changed, identifier-recycled, credential-compromise, opt-in, opt-out-initiated, opt-out-cancelled, opt-out-effective, recovery-activated, recovery-information-changed]
     description: |-
-      Supports all  (not yet supported)[RISC](https://github.com/openid/sse/blob/main/openid-risc-profile-specification-1_0.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
+      Supports all [RISC](https://openid.net/specs/openid-risc-profile-specification-1_0-01.html) and [CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     example: credential-compromise
   subject:
     allOf:

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -18,7 +18,7 @@ required:
 properties:
   event_type:
     type: string
-    enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change]
+    enum: [session-revoked, token-claims-change, credential-change, assurance-level-change, device-compliance-change, account-purged, account-disabled, account-enabled, identifier-changed, identifier-recycled, opt-in, opt-out-initiated, opt-out-cancelled, opt-out-effective, recovery-activated, recovery-information-changed, RISC-sessions-revoked]
     description: |-
       Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.
     example: credential-compromise

--- a/transmitter_spec/schemas/TriggerEventParameters.yaml
+++ b/transmitter_spec/schemas/TriggerEventParameters.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates
+# All rights reserved.
+# Use of this source code is governed by a BSD 3-Clause License
+# that can be found in the LICENSE file.
+
+type: object
+title: "Trigger Event Parameters"
+description: |
+  JSON Object describing request to create a security event to test SSE receiver/transmitter 
+example:
+  event_type: session-revoked
+  subject:
+    format: email
+    email: "user@example.com"
+required:
+  - event_type
+  - subject
+properties:
+  event_type:
+    type: string
+    description: |-
+      Read-Write.
+      Supports all  (not yet supported)[RISC](https://openid.net/specs/openid-risc-event-types-1_0-ID1.html) and (supported)[CAEP](https://openid.net/specs/openid-caep-specification-1_0-ID1.html) event types.      
+    example: credential-compromise
+  subject:
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/Subject"
+      - description: "REQUIRED. SHOULD be same as subjects receiver cares about (config.cfg). A Subject claim identifying the subject to be added."


### PR DESCRIPTION
## What kind of PR is this?

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind design

/kind cleanup
/kind documentation
/kind feature

> /kind failing-test
> /kind flake

## Solves Issue
https://github.com/duo-labs/sharedsignals/issues/60

## What this PR does / why we need it:
* Write-up to use this feature is [here](https://github.com/duo-labs/sharedsignals/tree/raj_event_gen/examples#trigger-and-test-sse-events-other-than-verification)
* Code to generate sse events and broadcast to all interested(subject) streams
* Added endpoint to trigger sse events
* Unit tests written and tested by checking if the triggered event is queued
* All REQUIRED fields of the SET are populated
* Some (only timestamp for now) fields of the SET are pseudo-random
* Mentioned use of pycodestyle in [contributing](https://github.com/duo-labs/sharedsignals/tree/raj_event_gen#contributing)

## Questions
 **Q:**  Is there a better way to support all types? Pedantic classes , etc in the current form take too much code and it isn’t quick and easy to add new event_types .
**Ans:** This is one of the best ways, as it does the validation of all attributes (some are enums as well), that are part of an event.


## PR format Acknowledgement:
Above PR format is stolen from
https://wwwin-github.cisco.com/slimshady/slimshady/
Big thanks to them