### PR TITLE
Update requirements.txt

### DIFF
--- a/examples/receiver/requirements.txt
+++ b/examples/receiver/requirements.txt
@@ -2,4 +2,5 @@ jwcrypto==1.0
 PyJWT==2.4.0
 requests==2.26.0
 typing-extensions==3.10.0.2
+Werkzeug==2.2.2
 Flask==2.0.2


### PR DESCRIPTION
The receiver in example might failed to build due to ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py)

Appending Werkzeug==2.2.2 to examples/receiver/requirements.txt helps. https://github.com/duo-labs/sharedsignals/issues/66